### PR TITLE
Fix relative path when uploading from current directory

### DIFF
--- a/pkg/az/storage-blob.go
+++ b/pkg/az/storage-blob.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/Azure/azure-storage-blob-go/2017-07-29/azblob"
@@ -37,9 +36,12 @@ func (a *App) UploadBlobBatch(sourceDirectory, containerName string) error {
 		wg.Add(1)
 		go func() {
 			for path := range files {
-				name := strings.Replace(path, sourceDirectory, "", 1)
-				name = strings.TrimLeft(name, string(os.PathSeparator))
-				err := a.uploadFile(path, name, containerURL)
+				name, err := filepath.Rel(sourceDirectory, path)
+				if err != nil {
+					log.Printf("skipping %q: %s", path, err)
+				}
+
+				err = a.uploadFile(path, name, containerURL)
 				if err != nil {
 					log.Print(err)
 				}

--- a/test/test.sh
+++ b/test/test.sh
@@ -8,8 +8,13 @@ AZ=${AZ:-az}
 echo "TEST: UploadBlob"
 $REPO_ROOT/bin/$AZ storage blob upload -f test/testdata/a.txt -c azcli -n a.txt
 
-echo "TEST: UploadBatch"
+echo "TEST: UploadBatch from reldir"
 $REPO_ROOT/bin/$AZ storage blob upload-batch -s test/testdata -d azcli
+
+echo "TEST: UploadBatch from curdir"
+pushd test/testdata
+$REPO_ROOT/bin/$AZ storage blob upload-batch -s . -d azcli
+popd
 
 echo "TEST: DownloadBlob"
 $REPO_ROOT/bin/$AZ storage blob download --container-name azcli --name a.txt --file test/testdata/a.txt

--- a/test/testdata/wordpress-0.10.1.txt
+++ b/test/testdata/wordpress-0.10.1.txt
@@ -1,0 +1,1 @@
+wordpress


### PR DESCRIPTION
When uploading from the current directory `.`, I was munging the filename. TIL about filepath.Rel which does this properly (finding the relative path from a directory, to another path).